### PR TITLE
Change the return value of getSoundsToPlay to get the right type for soundControl

### DIFF
--- a/IGame.hpp
+++ b/IGame.hpp
@@ -86,7 +86,7 @@ namespace arcade
     virtual std::vector<std::pair<std::string, SoundType>> getSoundsToLoad() const = 0;
 
     ///
-    /// \fn     virtual std::vector<Sound> const &getSoundsToPlay() = 0
+    /// \fn     virtual std::vector<Sound> getSoundsToPlay() = 0
     /// \brief Get the sounds to play
     ///  You should return by std::move to not copy your vector and to clear it at the same time
     ///


### PR DESCRIPTION
Since we must give a Sound argument to soundControl method from IGfxLib we need to get the same type from getSoundsToPlay in the IGame